### PR TITLE
Disable Scheduled GitHub Actions on Forks (#150)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   cuda_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: CUDA EB 2D
     runs-on: ubuntu-20.04
     steps:
@@ -61,6 +62,7 @@ jobs:
         du -hs ~/.cache/ccache
 
   cuda_no_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: CUDA NO EB 2D
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   gcc_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: GCC EB 3D
     runs-on: ubuntu-latest
     steps:
@@ -71,6 +72,7 @@ jobs:
         mpiexec -n 2 ./amr3d.gnu.MPI.ex regtest.3d.flow_past_cylinder-z max_step=3 ns.v=1 mac_proj.verbose=1 nodal_proj.verbose=1
 
   gcc_no_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: GCC NO EB 3D
     runs-on: ubuntu-latest
     steps:
@@ -129,6 +131,7 @@ jobs:
         mpiexec -n 2 ./amr3d.gnu.MPI.ex regtest.3d.euler max_step=3 ns.v=1 mac_proj.verbose=1 nodal_proj.verbose=1
 
   gcc_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: GCC EB 2D
     runs-on: ubuntu-latest
     steps:
@@ -188,6 +191,7 @@ jobs:
         ./amr2d.gnu.OMP.ex regtest.2d.flow_past_cylinder-x max_step=10 ns.v=1 mac_proj.verbose=1 nodal_proj.verbose=1
 
   gcc_no_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: GCC NO EB 2D
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   hip_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: HIP EB 3D
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   sycl_no_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/IAMR' || github.event_name != 'schedule' }}
     name: SYCL NO EB 3D
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The default branch on a fork is often out of sync with the main repo, resulting in failures in scheduled actions. This disables scheduled actions on forks. Note that `push` and `pull_request` still trigger GitHub actions on forks. If one wants to disable it entirely in their fork, follow the instruction in the link below.


https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow?tool=webui#disabling-a-workflow