### PR TITLE
fix bug with initialLargrangianPoint and velocityInterpolation 

### DIFF
--- a/Source/DiffusedIB.H
+++ b/Source/DiffusedIB.H
@@ -43,6 +43,7 @@ enum DELTA_FUNCTION_TYPE{
 };
 
 struct kernel{
+    int id;
     RealVect velocity;
     RealVect location;
     RealVect omega;
@@ -104,7 +105,7 @@ public:
                        int velocity_index,
                        int finest_level);
 
-    void InteractWithEuler(amrex::Real time, MultiFab &EulerVel, MultiFab &EulerForce, int loop_time = 20, Real dt = 0.1, Real alpha_k = 0.5, DELTA_FUNCTION_TYPE type = FOUR_POINT_IB);
+    void InteractWithEuler(int iStep, amrex::Real time, MultiFab &EulerVel, MultiFab &EulerForce, int loop_time = 20, Real dt = 0.1, Real alpha_k = 0.5, DELTA_FUNCTION_TYPE type = FOUR_POINT_IB);
 
     void WriteParticleFile(int index);
 
@@ -129,7 +130,7 @@ private:
 
     void ComputeLagrangianForce(Real dt, const kernel& kernel);
 
-    void WriteIBForce(amrex::Real time);
+    static void WriteIBForce(int step, amrex::Real time, kernel& current_kernel);
 
     uint32_t ib_forece_file_index = 0;
 

--- a/Source/DiffusedIB.H
+++ b/Source/DiffusedIB.H
@@ -51,6 +51,7 @@ struct kernel{
     Real rho;
     int ml;
     Real dv;
+    RealVect ib_forece;
     std::vector<amrex::Real> thetaK;
     std::vector<amrex::Real> phiK;
 };
@@ -103,11 +104,11 @@ public:
                        int velocity_index,
                        int finest_level);
 
-    void InteractWithEuler(MultiFab &EulerVel, MultiFab &EulerForce, int loop_time = 20, Real dt = 0.1, Real alpha_k = 0.5, DELTA_FUNCTION_TYPE type = FOUR_POINT_IB);
+    void InteractWithEuler(amrex::Real time, MultiFab &EulerVel, MultiFab &EulerForce, int loop_time = 20, Real dt = 0.1, Real alpha_k = 0.5, DELTA_FUNCTION_TYPE type = FOUR_POINT_IB);
 
     void WriteParticleFile(int index);
 
-// private:
+private:
     int euler_finest_level;
 
     int euler_force_index;
@@ -122,11 +123,15 @@ public:
 
     void VelocityInterpolation(amrex::MultiFab &Euler, DELTA_FUNCTION_TYPE type);
 
-    void ForceSpreading(amrex::MultiFab &Euler, Real dv, DELTA_FUNCTION_TYPE type);
+    void ForceSpreading(amrex::MultiFab &Euler, RealVect& ib_forece, Real dv, DELTA_FUNCTION_TYPE type);
 
     void UpdateParticles(const amrex::MultiFab& Euler, kernel& kernel, Real dt, Real alpha_k );
 
     void ComputeLagrangianForce(Real dt, const kernel& kernel);
+
+    void WriteIBForce(amrex::Real time);
+
+    uint32_t ib_forece_file_index = 0;
 
     int verbose = 0;
 };

--- a/Source/DiffusedIB.H
+++ b/Source/DiffusedIB.H
@@ -126,7 +126,7 @@ public:
 
     void ComputeLagrangianForce(Real dt, const kernel& kernel);
 
-    int verbose = 1;
+    int verbose = 0;
 };
 
 class Particles{

--- a/Source/DiffusedIB.H
+++ b/Source/DiffusedIB.H
@@ -49,7 +49,7 @@ struct kernel{
     RealVect varphi;
     Real radious;
     Real rho;
-    Real ml;
+    int ml;
     Real dv;
 };
 
@@ -118,7 +118,7 @@ public:
 
     void InitialWithLargrangianPoints(const kernel& current_kernel);
 
-    void VelocityInterpolation(const amrex::MultiFab &Euler, DELTA_FUNCTION_TYPE type);
+    void VelocityInterpolation(amrex::MultiFab &Euler, DELTA_FUNCTION_TYPE type);
 
     void ForceSpreading(amrex::MultiFab &Euler, DELTA_FUNCTION_TYPE type);
 
@@ -126,7 +126,7 @@ public:
 
     void ComputeLagrangianForce(Real dt, const kernel& kernel);
 
-    int verbose = 0;
+    int verbose = 1;
 };
 
 class Particles{

--- a/Source/DiffusedIB.H
+++ b/Source/DiffusedIB.H
@@ -51,6 +51,8 @@ struct kernel{
     Real rho;
     int ml;
     Real dv;
+    std::vector<amrex::Real> thetaK;
+    std::vector<amrex::Real> phiK;
 };
 
 class mParIter : public ParIter<0, 0, numAttri>{
@@ -120,7 +122,7 @@ public:
 
     void VelocityInterpolation(amrex::MultiFab &Euler, DELTA_FUNCTION_TYPE type);
 
-    void ForceSpreading(amrex::MultiFab &Euler, DELTA_FUNCTION_TYPE type);
+    void ForceSpreading(amrex::MultiFab &Euler, Real dv, DELTA_FUNCTION_TYPE type);
 
     void UpdateParticles(const amrex::MultiFab& Euler, kernel& kernel, Real dt, Real alpha_k );
 

--- a/Source/DiffusedIB.cpp
+++ b/Source/DiffusedIB.cpp
@@ -66,7 +66,7 @@ void deltaFunction(Real xf, Real xp, Real h, Real& value, DELTA_FUNCTION_TYPE ty
 
     switch (type) {
     case DELTA_FUNCTION_TYPE::FOUR_POINT_IB:
-        if(rr >= 0 && rr < 0.5 ){
+        if(rr >= 0 && rr < 1 ){
             value = 1.0 / 8.0 * ( 3.0 - 2.0 * rr + std::sqrt( 1.0 + 4.0 * rr - 4 * Math::powi<2>(rr))) / h;
         }else if (rr >= 1 && rr < 2) {
             value = 1.0 / 8.0 * ( 5.0 - 2.0 * rr - std::sqrt( -7.0 + 12.0 * rr - 4 * Math::powi<2>(rr))) / h;
@@ -75,9 +75,9 @@ void deltaFunction(Real xf, Real xp, Real h, Real& value, DELTA_FUNCTION_TYPE ty
         }
         break;
     case DELTA_FUNCTION_TYPE::THREE_POINT_IB:
-        if(rr >= 0 && rr < 1){
+        if(rr >= 0 && rr < 0.5){
             value = 1.0 / 6.0 * ( 5.0 - 3.0 * rr + std::sqrt( - 3.0 * ( 1 - Math::powi<2>(rr)) + 1.0 )) / h;
-        }else if (rr >= 1 && rr < 2) {
+        }else if (rr >= 0.5 && rr < 1.5) {
             value = 1.0 / 3.0 * ( 1.0 + std::sqrt( 1.0 - 3 * Math::powi<2>(rr))) / h;
         }else {
             value = 0;
@@ -101,13 +101,14 @@ void mParticle::InteractWithEuler(MultiFab &EulerVel, MultiFab &EulerForce, int 
         Redistribute();
         //UpdateParticles(Euler, kernel, dt, alpha_k);
         //for 1 -> Ns
-        while(loop_time > 0){
+        int loop = loop_time;
+        while(loop > 0){
             EulerForce.setVal(0.0, euler_force_index, 3, EulerForce.nGrow()); //clear Euler force
             VelocityInterpolation(EulerVel, type);
             ComputeLagrangianForce(dt, kernel);
             ForceSpreading(EulerForce, type);
             MultiFab::Saxpy(EulerVel, dt, EulerForce, euler_force_index, euler_velocity_index, 3, 0); //VelocityCorrection
-            loop_time--;
+            loop--;
         }
     }
 }

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -2651,7 +2651,7 @@ NavierStokes::advance_semistaggered_fsi_diffusedib (Real time,
             // S_new.setVal(2.0, 1, 1, S_new.nGrow()); // v = 2
             // S_new.setVal(3.0, 2, 1, S_new.nGrow()); // w = 3
             MultiFab EulerForce(S_new.boxArray(), S_new.DistributionMap(), 3, S_new.nGrow());            
-            Particles::get_particles()->InteractWithEuler(S_new, EulerForce, 1, dt, 0.5);
+            Particles::get_particles()->InteractWithEuler(parent->levelSteps(0), time, S_new, EulerForce, 10, dt, 0.5);
         }
         //amrex::Abort("Stop here!");
 #endif


### PR DESCRIPTION
Modify the function `InitialWithLargrangianPoints` and  `VelocityInterpolation`,
 > considering the ghost cell problem and the particle problem under multiple boxes.